### PR TITLE
Removed unexport of iterate:terminate

### DIFF
--- a/lisp-meta-fs-test.lisp
+++ b/lisp-meta-fs-test.lisp
@@ -6,9 +6,6 @@
 #+sbcl (require :sb-posix)
 (require :iterate)
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (unexport 'iterate:terminate :iterate))
-
 (use-package :cl-fuse-meta-fs)
 (use-package :iterate)
 


### PR DESCRIPTION
terminate is not exported in current version of iterate.
Comilation fails when unexport is run.
